### PR TITLE
Allow the vs record's precision to be specified by the PREC field

### DIFF
--- a/vacApp/Db/vs_settings.req
+++ b/vacApp/Db/vs_settings.req
@@ -1,0 +1,2 @@
+$(P)$(GAUGE).PREC
+

--- a/vacApp/src/vsRecord.c
+++ b/vacApp/src/vsRecord.c
@@ -270,19 +270,20 @@ static long get_control_double(DBADDR *paddr, struct dbr_ctrlDouble * pcd)
  ******************************************************************************/
 static long get_precision(const DBADDR *paddr, long *precision)
 {
+    vsRecord *pvs = (vsRecord *)paddr->precord;
     int fieldIndex = dbGetFieldIndex(paddr);
 
+    *precision = pvs->prec;
     if (fieldIndex == vsRecordVAL || fieldIndex == vsRecordPRES
       || fieldIndex == vsRecordCGAP || fieldIndex == vsRecordCGBP
       || fieldIndex == vsRecordSP1R || fieldIndex == vsRecordSP2R
       || fieldIndex == vsRecordSP3R || fieldIndex == vsRecordSP4R) {
-        *precision = 1;
         return 0;
     }
     if (fieldIndex == vsRecordLPRS
       || fieldIndex == vsRecordLCAP
       || fieldIndex == vsRecordLCBP) {
-        *precision = 2;
+        *precision = pvs->prec + 1;
         return 0;
     }
     *precision = 0;

--- a/vacApp/src/vsRecord.dbd
+++ b/vacApp/src/vsRecord.dbd
@@ -39,6 +39,12 @@ recordtype(vs) {
 		initial("5")
 		interest(1)
 	}
+	field(PREC,DBF_SHORT) {
+		prompt("Display Precision")
+		promptgroup(GUI_DISPLAY)
+		interest(1)
+		initial("1")
+	}
 	field(IG1S,DBF_MENU) {
 		prompt("Ion Gauge 1 Set")
 		promptgroup(GUI_ALARMS)


### PR DESCRIPTION
Allow the vs record's precision to be specified by the PREC field.

Commit https://github.com/epics-modules/vac/commit/eef412ef5de69c2e53cead10aaf98e5391c82706 includes changes suggested by Claude Opus 4.6 via Argo.  

The changes "work" and have been tested at 3ID-B, however, it isn't obvious to me if other modifiations are required.  I'm not familiar enough with all the devices supported by the vs record, so I don't know which fields in get_precision should be controlled by the PREC field and which, if any, should remain hard-coded.